### PR TITLE
Removing Jest from repo

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,0 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.export = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-    reporters: [
-        'default', 'github-actions', "jest-junit"
-    ]
-};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "types": ["node", "jest", "mocha"],
+    "types": ["node", "mocha"],
     "module": "commonjs",
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
We are using Mocha for testing so Jest is no longer needed. Also it was throwing errors in the pipeline